### PR TITLE
Compile against Rust 1.85.0 on Windows and bump crate versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,4 +35,4 @@ indoc = "2.0.5"
 winres = "0.1"
 
 [build-dependencies]
-vergen = "7.1.0"
+vergen = "7.5.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,13 +23,13 @@ ProductVersion = "1.0"
 
 [dependencies]
 winapi = { version = "0.3.9", features = ["winuser", "commdlg", "shobjidl", "shobjidl_core", "combaseapi", "objbase", "winbase", "winerror"] }
-scopeguard = "1.1.0"
-lazy_static = "1.4.0"
-log = "0.4.14"
-simplelog = "0.10.0"
-chrono = "0.4.19"
-regex = "1.4.5"
-indoc = "1.0.3"
+scopeguard = "1.2.0"
+lazy_static = "1.5.0"
+log = "0.4.26"
+simplelog = "0.12.2"
+chrono = "0.4.39"
+regex = "1.11.1"
+indoc = "2.0.5"
 
 [target.'cfg(windows)'.build-dependencies]
 winres = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ ProductName = "Xanthidae"
 ProductVersion = "1.0"
 
 [dependencies]
-winapi = { version = "0.3.9", features = ["winuser", "commdlg", "shobjidl", "shobjidl_core", "combaseapi", "objbase", "winbase"] }
+winapi = { version = "0.3.9", features = ["winuser", "commdlg", "shobjidl", "shobjidl_core", "combaseapi", "objbase", "winbase", "winerror"] }
 scopeguard = "1.1.0"
 lazy_static = "1.4.0"
 log = "0.4.14"

--- a/src/windows_api.rs
+++ b/src/windows_api.rs
@@ -1,7 +1,7 @@
 use std::ffi::{CStr, CString};
 use std::mem::MaybeUninit;
 use std::os::raw::c_uint;
-use std::os::raw::{c_char, c_int, c_void};
+use std::os::raw::{c_char, c_int};
 use std::{mem, ptr};
 
 use winapi::shared::winerror::SUCCEEDED;
@@ -113,7 +113,7 @@ pub fn get_save_folder_name() -> String {
                 ptr::null_mut(),
                 CLSCTX_INPROC,
                 &IFileOpenDialog::uuidof(),
-                file_open_dialog.as_mut_ptr() as *mut *mut c_void,
+                file_open_dialog.as_mut_ptr() as *mut *mut winapi::ctypes::c_void,
             );
 
             if SUCCEEDED(hr) {
@@ -136,7 +136,7 @@ pub fn get_save_folder_name() -> String {
                         if SUCCEEDED((*shell_item).GetDisplayName(SIGDN_FILESYSPATH, &mut buffer)) {
                             selected_folder = pwstr_to_cstring(buffer);
                         }
-                        CoTaskMemFree(buffer as *mut std::ffi::c_void);
+                        CoTaskMemFree(buffer as *mut winapi::ctypes::c_void);
                     }
                     (*shell_item).Release();
                 }


### PR DESCRIPTION
- Rust 1.85.0 failed to compile the code with errors in the `winapi` code.
- Bumped create versions.